### PR TITLE
python3 compatible syntax

### DIFF
--- a/glibs/ndbkeyparser/ProtocolBuffer.py
+++ b/glibs/ndbkeyparser/ProtocolBuffer.py
@@ -19,7 +19,7 @@
 
 
 import array
-import httplib
+import http.client
 import re
 import struct
 
@@ -39,13 +39,13 @@ class ProtocolMessage:
 
 
   def __init__(self, contents=None):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def Clear(self):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def IsInitialized(self, debug_strs=None):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def Encode(self):
     try:
@@ -67,10 +67,10 @@ class ProtocolMessage:
       return e.buffer().tostring()
 
   def _CEncode(self):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def _CEncodePartial(self):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def ParseFromString(self, s):
     self.Clear()
@@ -84,7 +84,7 @@ class ProtocolMessage:
     self.MergePartialFromString(s)
     dbg = []
     if not self.IsInitialized(dbg):
-      raise ProtocolBufferDecodeError, '\n\t'.join(dbg)
+      raise ProtocolBufferDecodeError('\n\t'.join(dbg))
 
   def MergePartialFromString(self, s):
     try:
@@ -98,7 +98,7 @@ class ProtocolMessage:
       self.TryMerge(d)
 
   def _CMergeFromString(self, s):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def __getstate__(self):
     return self.Encode()
@@ -111,12 +111,12 @@ class ProtocolMessage:
     data = self.Encode()
     if secure:
       if keyfile and certfile:
-        conn = httplib.HTTPSConnection(server, key_file=keyfile,
+        conn = http.client.HTTPSConnection(server, key_file=keyfile,
                                        cert_file=certfile)
       else:
-        conn = httplib.HTTPSConnection(server)
+        conn = http.client.HTTPSConnection(server)
     else:
-      conn = httplib.HTTPConnection(server)
+      conn = http.client.HTTPConnection(server)
     conn.putrequest("POST", url)
     conn.putheader("Content-Length", "%d" %len(data))
     conn.endheaders()
@@ -144,7 +144,7 @@ class ProtocolMessage:
                             secure=1, keyfile=keyfile, certfile=certfile)
 
   def __str__(self, prefix="", printElemNumber=0):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def ToASCII(self):
     return self._CToASCII(ProtocolMessage._SYMBOLIC_FULL_ASCII)
@@ -162,16 +162,16 @@ class ProtocolMessage:
   _SYMBOLIC_FULL_ASCII = 2
 
   def _CToASCII(self, output_format):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def ParseASCII(self, ascii_string):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def ParseASCIIIgnoreUnknown(self, ascii_string):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def Equals(self, other):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def __eq__(self, other):
 
@@ -200,15 +200,15 @@ class ProtocolMessage:
   def Output(self, e):
     dbg = []
     if not self.IsInitialized(dbg):
-      raise ProtocolBufferEncodeError, '\n\t'.join(dbg)
+      raise ProtocolBufferEncodeError('\n\t'.join(dbg))
     self.OutputUnchecked(e)
     return
 
   def OutputUnchecked(self, e):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def OutputPartial(self, e):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def Parse(self, d):
     self.Clear()
@@ -219,11 +219,11 @@ class ProtocolMessage:
     self.TryMerge(d)
     dbg = []
     if not self.IsInitialized(dbg):
-      raise ProtocolBufferDecodeError, '\n\t'.join(dbg)
+      raise ProtocolBufferDecodeError('\n\t'.join(dbg))
     return
 
   def TryMerge(self, d):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def CopyFrom(self, pb):
     if (pb == self): return
@@ -231,7 +231,7 @@ class ProtocolMessage:
     self.MergeFrom(pb)
 
   def MergeFrom(self, pb):
-    raise NotImplementedError
+    raise NotImplementedError()
 
 
 
@@ -282,10 +282,10 @@ class ProtocolMessage:
   def DebugFormatFloat(self, value):
     return "%ff" % value
   def DebugFormatFixed32(self, value):
-    if (value < 0): value += (1L<<32)
+    if (value < 0): value += (1<<32)
     return "0x%x" % value
   def DebugFormatFixed64(self, value):
-    if (value < 0): value += (1L<<64)
+    if (value < 0): value += (1<<64)
     return "0x%x" % value
   def DebugFormatBool(self, value):
     if value:
@@ -338,18 +338,18 @@ class Encoder:
     return self.buf
 
   def put8(self, v):
-    if v < 0 or v >= (1<<8): raise ProtocolBufferEncodeError, "u8 too big"
+    if v < 0 or v >= (1<<8): raise ProtocolBufferEncodeError("u8 too big")
     self.buf.append(v & 255)
     return
 
   def put16(self, v):
-    if v < 0 or v >= (1<<16): raise ProtocolBufferEncodeError, "u16 too big"
+    if v < 0 or v >= (1<<16): raise ProtocolBufferEncodeError("u16 too big")
     self.buf.append((v >> 0) & 255)
     self.buf.append((v >> 8) & 255)
     return
 
   def put32(self, v):
-    if v < 0 or v >= (1L<<32): raise ProtocolBufferEncodeError, "u32 too big"
+    if v < 0 or v >= (1<<32): raise ProtocolBufferEncodeError("u32 too big")
     self.buf.append((v >> 0) & 255)
     self.buf.append((v >> 8) & 255)
     self.buf.append((v >> 16) & 255)
@@ -357,7 +357,7 @@ class Encoder:
     return
 
   def put64(self, v):
-    if v < 0 or v >= (1L<<64): raise ProtocolBufferEncodeError, "u64 too big"
+    if v < 0 or v >= (1<<64): raise ProtocolBufferEncodeError("u64 too big")
     self.buf.append((v >> 0) & 255)
     self.buf.append((v >> 8) & 255)
     self.buf.append((v >> 16) & 255)
@@ -382,7 +382,7 @@ class Encoder:
       buf_append(v)
       return
     if v >= 0x80000000 or v < -0x80000000:
-      raise ProtocolBufferEncodeError, "int32 too big"
+      raise ProtocolBufferEncodeError("int32 too big")
     if v < 0:
       v += 0x10000000000000000
     while True:
@@ -398,7 +398,7 @@ class Encoder:
   def putVarInt64(self, v):
     buf_append = self.buf.append
     if v >= 0x8000000000000000 or v < -0x8000000000000000:
-      raise ProtocolBufferEncodeError, "int64 too big"
+      raise ProtocolBufferEncodeError("int64 too big")
     if v < 0:
       v += 0x10000000000000000
     while True:
@@ -414,7 +414,7 @@ class Encoder:
   def putVarUint64(self, v):
     buf_append = self.buf.append
     if v < 0 or v >= 0x10000000000000000:
-      raise ProtocolBufferEncodeError, "uint64 too big"
+      raise ProtocolBufferEncodeError("uint64 too big")
     while True:
       bits = v & 127
       v >>= 7
@@ -496,7 +496,7 @@ class Decoder:
     return self.idx
 
   def skip(self, n):
-    if self.idx + n > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + n > self.limit: raise ProtocolBufferDecodeError("truncated")
     self.idx += n
     return
 
@@ -517,47 +517,47 @@ class Decoder:
         else:
           self.skipData(t)
       if (t - Encoder.ENDGROUP) != (tag - Encoder.STARTGROUP):
-        raise ProtocolBufferDecodeError, "corrupted"
+        raise ProtocolBufferDecodeError("corrupted")
     elif t == Encoder.ENDGROUP:
-      raise ProtocolBufferDecodeError, "corrupted"
+      raise ProtocolBufferDecodeError("corrupted")
     elif t == Encoder.FLOAT:
       self.skip(4)
     else:
-      raise ProtocolBufferDecodeError, "corrupted"
+      raise ProtocolBufferDecodeError("corrupted")
 
 
   def get8(self):
-    if self.idx >= self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx >= self.limit: raise ProtocolBufferDecodeError("truncated")
     c = self.buf[self.idx]
     self.idx += 1
     return c
 
   def get16(self):
-    if self.idx + 2 > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + 2 > self.limit: raise ProtocolBufferDecodeError("truncated")
     c = self.buf[self.idx]
     d = self.buf[self.idx + 1]
     self.idx += 2
     return (d << 8) | c
 
   def get32(self):
-    if self.idx + 4 > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + 4 > self.limit: raise ProtocolBufferDecodeError("truncated")
     c = self.buf[self.idx]
     d = self.buf[self.idx + 1]
     e = self.buf[self.idx + 2]
-    f = long(self.buf[self.idx + 3])
+    f = int(self.buf[self.idx + 3])
     self.idx += 4
     return (f << 24) | (e << 16) | (d << 8) | c
 
   def get64(self):
-    if self.idx + 8 > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + 8 > self.limit: raise ProtocolBufferDecodeError("truncated")
     c = self.buf[self.idx]
     d = self.buf[self.idx + 1]
     e = self.buf[self.idx + 2]
-    f = long(self.buf[self.idx + 3])
-    g = long(self.buf[self.idx + 4])
-    h = long(self.buf[self.idx + 5])
-    i = long(self.buf[self.idx + 6])
-    j = long(self.buf[self.idx + 7])
+    f = int(self.buf[self.idx + 3])
+    g = int(self.buf[self.idx + 4])
+    h = int(self.buf[self.idx + 5])
+    i = int(self.buf[self.idx + 6])
+    j = int(self.buf[self.idx + 7])
     self.idx += 8
     return ((j << 56) | (i << 48) | (h << 40) | (g << 32) | (f << 24)
             | (e << 16) | (d << 8) | c)
@@ -570,65 +570,65 @@ class Decoder:
     if not (b & 128):
       return b
 
-    result = long(0)
+    result = int(0)
     shift = 0
 
     while 1:
-      result |= (long(b & 127) << shift)
+      result |= (int(b & 127) << shift)
       shift += 7
       if not (b & 128):
-        if result >= 0x10000000000000000L:
-          raise ProtocolBufferDecodeError, "corrupted"
+        if result >= 0x10000000000000000:
+          raise ProtocolBufferDecodeError("corrupted")
         break
-      if shift >= 64: raise ProtocolBufferDecodeError, "corrupted"
+      if shift >= 64: raise ProtocolBufferDecodeError("corrupted")
       b = self.get8()
 
-    if result >= 0x8000000000000000L:
-      result -= 0x10000000000000000L
-    if result >= 0x80000000L or result < -0x80000000L:
-      raise ProtocolBufferDecodeError, "corrupted"
+    if result >= 0x8000000000000000:
+      result -= 0x10000000000000000
+    if result >= 0x80000000 or result < -0x80000000:
+      raise ProtocolBufferDecodeError("corrupted")
     return result
 
   def getVarInt64(self):
     result = self.getVarUint64()
-    if result >= (1L << 63):
-      result -= (1L << 64)
+    if result >= (1 << 63):
+      result -= (1 << 64)
     return result
 
   def getVarUint64(self):
-    result = long(0)
+    result = int(0)
     shift = 0
     while 1:
-      if shift >= 64: raise ProtocolBufferDecodeError, "corrupted"
+      if shift >= 64: raise ProtocolBufferDecodeError("corrupted")
       b = self.get8()
-      result |= (long(b & 127) << shift)
+      result |= (int(b & 127) << shift)
       shift += 7
       if not (b & 128):
-        if result >= (1L << 64): raise ProtocolBufferDecodeError, "corrupted"
+        if result >= (1 << 64): raise ProtocolBufferDecodeError("corrupted")
         return result
     return result
 
   def getFloat(self):
-    if self.idx + 4 > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + 4 > self.limit: raise ProtocolBufferDecodeError("truncated")
     a = self.buf[self.idx:self.idx+4]
     self.idx += 4
     return struct.unpack("<f", a)[0]
 
   def getDouble(self):
-    if self.idx + 8 > self.limit: raise ProtocolBufferDecodeError, "truncated"
+    if self.idx + 8 > self.limit: raise ProtocolBufferDecodeError("truncated")
     a = self.buf[self.idx:self.idx+8]
     self.idx += 8
     return struct.unpack("<d", a)[0]
 
   def getBoolean(self):
     b = self.get8()
-    if b != 0 and b != 1: raise ProtocolBufferDecodeError, "corrupted"
+    if b != 0 and b != 1: raise ProtocolBufferDecodeError("corrupted")
     return b
 
   def getPrefixedString(self):
     length = self.getVarInt32()
     if self.idx + length > self.limit:
-      raise ProtocolBufferDecodeError, "truncated"
+      raise ProtocolBufferDecodeError("truncated")
     r = self.buf[self.idx : self.idx + length]
     self.idx += length
     return r.tostring()
@@ -785,9 +785,9 @@ class ExtendableProtocolMessage(ProtocolMessage):
                          self.__class__.__name__))
 
   def _MergeExtensionFields(self, x):
-    for ext, val in x._extension_fields.items():
+    for ext, val in list(x._extension_fields.items()):
       if ext.is_repeated:
-        for i in xrange(len(val)):
+        for i in range(len(val)):
           if ext.composite_cls is None:
             self.AddExtension(ext, val[i])
           else:
@@ -799,7 +799,7 @@ class ExtendableProtocolMessage(ProtocolMessage):
           self.MutableExtension(ext).MergeFrom(val)
 
   def _ListExtensions(self):
-    result = [ext for ext in self._extension_fields.keys()
+    result = [ext for ext in list(self._extension_fields.keys())
               if (not ext.is_repeated) or self.ExtensionSize(ext) > 0]
     result.sort(key = lambda item: item.number)
     return result
@@ -839,13 +839,13 @@ class ExtendableProtocolMessage(ProtocolMessage):
         Encoder._TYPE_TO_METHOD[ext.field_type](out, value)
 
     size = len(extensions)
-    for ext_index in xrange(start_index, size):
+    for ext_index in range(start_index, size):
       ext = extensions[ext_index]
       if ext.number >= end_field_number:
 
         return ext_index
       if ext.is_repeated:
-        for i in xrange(len(self._extension_fields[ext])):
+        for i in range(len(self._extension_fields[ext])):
           OutputSingleField(ext, self._extension_fields[ext][i])
       else:
         OutputSingleField(ext, self._extension_fields[ext])
@@ -883,7 +883,7 @@ class ExtendableProtocolMessage(ProtocolMessage):
 
   def _ExtensionByteSize(self, partial):
     size = 0
-    for extension, value in self._extension_fields.items():
+    for extension, value in list(self._extension_fields.items()):
       ftype = extension.field_type
       tag_size = self.lengthVarInt64(extension.wire_tag)
       if ftype == TYPE_GROUP:

--- a/glibs/ndbkeyparser/entity_pb.py
+++ b/glibs/ndbkeyparser/entity_pb.py
@@ -15,11 +15,9 @@
 # limitations under the License.
 #
 
-
-
-import ProtocolBuffer
+from . import ProtocolBuffer
 import array
-import dummy_thread as thread
+import _dummy_thread as thread
 
 __pychecker__ = """maxreturns=0 maxbranches=0 no-callinit
                    unusednames=printElemNumber,debug_strs no-special"""
@@ -163,7 +161,7 @@ class PropertyValue_ReferenceValuePathElement(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -277,7 +275,7 @@ class PropertyValue_PointValue(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -549,7 +547,7 @@ class PropertyValue_UserValue(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -621,7 +619,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
     assert x is not self
     if (x.has_app()): self.set_app(x.app())
     if (x.has_name_space()): self.set_name_space(x.name_space())
-    for i in xrange(x.pathelement_size()): self.add_pathelement().CopyFrom(x.pathelement(i))
+    for i in range(x.pathelement_size()): self.add_pathelement().CopyFrom(x.pathelement(i))
 
   def Equals(self, x):
     if x is self: return 1
@@ -649,7 +647,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
     n += self.lengthString(len(self.app_))
     if (self.has_name_space_): n += 2 + self.lengthString(len(self.name_space_))
     n += 2 * len(self.pathelement_)
-    for i in xrange(len(self.pathelement_)): n += self.pathelement_[i].ByteSize()
+    for i in range(len(self.pathelement_)): n += self.pathelement_[i].ByteSize()
     return n + 1
 
   def ByteSizePartial(self):
@@ -659,7 +657,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
       n += self.lengthString(len(self.app_))
     if (self.has_name_space_): n += 2 + self.lengthString(len(self.name_space_))
     n += 2 * len(self.pathelement_)
-    for i in xrange(len(self.pathelement_)): n += self.pathelement_[i].ByteSizePartial()
+    for i in range(len(self.pathelement_)): n += self.pathelement_[i].ByteSizePartial()
     return n
 
   def Clear(self):
@@ -670,7 +668,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
   def OutputUnchecked(self, out):
     out.putVarInt32(106)
     out.putPrefixedString(self.app_)
-    for i in xrange(len(self.pathelement_)):
+    for i in range(len(self.pathelement_)):
       out.putVarInt32(115)
       self.pathelement_[i].OutputUnchecked(out)
       out.putVarInt32(116)
@@ -682,7 +680,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
     if (self.has_app_):
       out.putVarInt32(106)
       out.putPrefixedString(self.app_)
-    for i in xrange(len(self.pathelement_)):
+    for i in range(len(self.pathelement_)):
       out.putVarInt32(115)
       self.pathelement_[i].OutputPartial(out)
       out.putVarInt32(116)
@@ -705,7 +703,7 @@ class PropertyValue_ReferenceValue(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -997,7 +995,7 @@ class PropertyValue(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -1023,7 +1021,7 @@ class PropertyValue(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kint64Value = 1
   kbooleanValue = 2
@@ -1456,7 +1454,7 @@ class Property(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -1477,7 +1475,7 @@ class Property(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kmeaning = 1
   kmeaning_uri = 2
@@ -1648,7 +1646,7 @@ class Path_Element(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -1684,7 +1682,7 @@ class Path(ProtocolBuffer.ProtocolMessage):
 
   def MergeFrom(self, x):
     assert x is not self
-    for i in xrange(x.element_size()): self.add_element().CopyFrom(x.element(i))
+    for i in range(x.element_size()): self.add_element().CopyFrom(x.element(i))
 
   def Equals(self, x):
     if x is self: return 1
@@ -1702,26 +1700,26 @@ class Path(ProtocolBuffer.ProtocolMessage):
   def ByteSize(self):
     n = 0
     n += 2 * len(self.element_)
-    for i in xrange(len(self.element_)): n += self.element_[i].ByteSize()
+    for i in range(len(self.element_)): n += self.element_[i].ByteSize()
     return n
 
   def ByteSizePartial(self):
     n = 0
     n += 2 * len(self.element_)
-    for i in xrange(len(self.element_)): n += self.element_[i].ByteSizePartial()
+    for i in range(len(self.element_)): n += self.element_[i].ByteSizePartial()
     return n
 
   def Clear(self):
     self.clear_element()
 
   def OutputUnchecked(self, out):
-    for i in xrange(len(self.element_)):
+    for i in range(len(self.element_)):
       out.putVarInt32(11)
       self.element_[i].OutputUnchecked(out)
       out.putVarInt32(12)
 
   def OutputPartial(self, out):
-    for i in xrange(len(self.element_)):
+    for i in range(len(self.element_)):
       out.putVarInt32(11)
       self.element_[i].OutputPartial(out)
       out.putVarInt32(12)
@@ -1734,7 +1732,7 @@ class Path(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -1752,7 +1750,7 @@ class Path(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kElementGroup = 1
   kElementtype = 2
@@ -1916,7 +1914,7 @@ class Reference(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -1932,7 +1930,7 @@ class Reference(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kapp = 13
   kname_space = 20
@@ -2217,7 +2215,7 @@ class User(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -2234,7 +2232,7 @@ class User(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kemail = 1
   kauth_domain = 2
@@ -2419,8 +2417,8 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
     if (x.has_owner()): self.mutable_owner().MergeFrom(x.owner())
     if (x.has_kind()): self.set_kind(x.kind())
     if (x.has_kind_uri()): self.set_kind_uri(x.kind_uri())
-    for i in xrange(x.property_size()): self.add_property().CopyFrom(x.property(i))
-    for i in xrange(x.raw_property_size()): self.add_raw_property().CopyFrom(x.raw_property(i))
+    for i in range(x.property_size()): self.add_property().CopyFrom(x.property(i))
+    for i in range(x.raw_property_size()): self.add_raw_property().CopyFrom(x.raw_property(i))
     if (x.has_rank()): self.set_rank(x.rank())
 
   def Equals(self, x):
@@ -2472,9 +2470,9 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
     if (self.has_kind_): n += 1 + self.lengthVarInt64(self.kind_)
     if (self.has_kind_uri_): n += 1 + self.lengthString(len(self.kind_uri_))
     n += 1 * len(self.property_)
-    for i in xrange(len(self.property_)): n += self.lengthString(self.property_[i].ByteSize())
+    for i in range(len(self.property_)): n += self.lengthString(self.property_[i].ByteSize())
     n += 1 * len(self.raw_property_)
-    for i in xrange(len(self.raw_property_)): n += self.lengthString(self.raw_property_[i].ByteSize())
+    for i in range(len(self.raw_property_)): n += self.lengthString(self.raw_property_[i].ByteSize())
     if (self.has_rank_): n += 2 + self.lengthVarInt64(self.rank_)
     return n + 3
 
@@ -2490,9 +2488,9 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
     if (self.has_kind_): n += 1 + self.lengthVarInt64(self.kind_)
     if (self.has_kind_uri_): n += 1 + self.lengthString(len(self.kind_uri_))
     n += 1 * len(self.property_)
-    for i in xrange(len(self.property_)): n += self.lengthString(self.property_[i].ByteSizePartial())
+    for i in range(len(self.property_)): n += self.lengthString(self.property_[i].ByteSizePartial())
     n += 1 * len(self.raw_property_)
-    for i in xrange(len(self.raw_property_)): n += self.lengthString(self.raw_property_[i].ByteSizePartial())
+    for i in range(len(self.raw_property_)): n += self.lengthString(self.raw_property_[i].ByteSizePartial())
     if (self.has_rank_): n += 2 + self.lengthVarInt64(self.rank_)
     return n
 
@@ -2516,11 +2514,11 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
     out.putVarInt32(106)
     out.putVarInt32(self.key_.ByteSize())
     self.key_.OutputUnchecked(out)
-    for i in xrange(len(self.property_)):
+    for i in range(len(self.property_)):
       out.putVarInt32(114)
       out.putVarInt32(self.property_[i].ByteSize())
       self.property_[i].OutputUnchecked(out)
-    for i in xrange(len(self.raw_property_)):
+    for i in range(len(self.raw_property_)):
       out.putVarInt32(122)
       out.putVarInt32(self.raw_property_[i].ByteSize())
       self.raw_property_[i].OutputUnchecked(out)
@@ -2546,11 +2544,11 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
       out.putVarInt32(106)
       out.putVarInt32(self.key_.ByteSizePartial())
       self.key_.OutputPartial(out)
-    for i in xrange(len(self.property_)):
+    for i in range(len(self.property_)):
       out.putVarInt32(114)
       out.putVarInt32(self.property_[i].ByteSizePartial())
       self.property_[i].OutputPartial(out)
-    for i in xrange(len(self.raw_property_)):
+    for i in range(len(self.raw_property_)):
       out.putVarInt32(122)
       out.putVarInt32(self.raw_property_[i].ByteSizePartial())
       self.raw_property_[i].OutputPartial(out)
@@ -2610,7 +2608,7 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -2651,7 +2649,7 @@ class EntityProto(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kkey = 13
   kentity_group = 16
@@ -2730,7 +2728,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
   def MergeFrom(self, x):
     assert x is not self
     if (x.has_index_id()): self.set_index_id(x.index_id())
-    for i in xrange(x.value_size()): self.add_value(x.value(i))
+    for i in range(x.value_size()): self.add_value(x.value(i))
 
   def Equals(self, x):
     if x is self: return 1
@@ -2753,7 +2751,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
     n = 0
     n += self.lengthVarInt64(self.index_id_)
     n += 1 * len(self.value_)
-    for i in xrange(len(self.value_)): n += self.lengthString(len(self.value_[i]))
+    for i in range(len(self.value_)): n += self.lengthString(len(self.value_[i]))
     return n + 1
 
   def ByteSizePartial(self):
@@ -2762,7 +2760,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
       n += 1
       n += self.lengthVarInt64(self.index_id_)
     n += 1 * len(self.value_)
-    for i in xrange(len(self.value_)): n += self.lengthString(len(self.value_[i]))
+    for i in range(len(self.value_)): n += self.lengthString(len(self.value_[i]))
     return n
 
   def Clear(self):
@@ -2772,7 +2770,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
   def OutputUnchecked(self, out):
     out.putVarInt32(8)
     out.putVarInt64(self.index_id_)
-    for i in xrange(len(self.value_)):
+    for i in range(len(self.value_)):
       out.putVarInt32(18)
       out.putPrefixedString(self.value_[i])
 
@@ -2780,7 +2778,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
     if (self.has_index_id_):
       out.putVarInt32(8)
       out.putVarInt64(self.index_id_)
-    for i in xrange(len(self.value_)):
+    for i in range(len(self.value_)):
       out.putVarInt32(18)
       out.putPrefixedString(self.value_[i])
 
@@ -2795,7 +2793,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -2812,7 +2810,7 @@ class CompositeProperty(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kindex_id = 1
   kvalue = 2
@@ -2948,7 +2946,7 @@ class Index_Property(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3015,7 +3013,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
     assert x is not self
     if (x.has_entity_type()): self.set_entity_type(x.entity_type())
     if (x.has_ancestor()): self.set_ancestor(x.ancestor())
-    for i in xrange(x.property_size()): self.add_property().CopyFrom(x.property(i))
+    for i in range(x.property_size()): self.add_property().CopyFrom(x.property(i))
 
   def Equals(self, x):
     if x is self: return 1
@@ -3046,7 +3044,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
     n = 0
     n += self.lengthString(len(self.entity_type_))
     n += 2 * len(self.property_)
-    for i in xrange(len(self.property_)): n += self.property_[i].ByteSize()
+    for i in range(len(self.property_)): n += self.property_[i].ByteSize()
     return n + 3
 
   def ByteSizePartial(self):
@@ -3057,7 +3055,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
     if (self.has_ancestor_):
       n += 2
     n += 2 * len(self.property_)
-    for i in xrange(len(self.property_)): n += self.property_[i].ByteSizePartial()
+    for i in range(len(self.property_)): n += self.property_[i].ByteSizePartial()
     return n
 
   def Clear(self):
@@ -3068,7 +3066,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
   def OutputUnchecked(self, out):
     out.putVarInt32(10)
     out.putPrefixedString(self.entity_type_)
-    for i in xrange(len(self.property_)):
+    for i in range(len(self.property_)):
       out.putVarInt32(19)
       self.property_[i].OutputUnchecked(out)
       out.putVarInt32(20)
@@ -3079,7 +3077,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
     if (self.has_entity_type_):
       out.putVarInt32(10)
       out.putPrefixedString(self.entity_type_)
-    for i in xrange(len(self.property_)):
+    for i in range(len(self.property_)):
       out.putVarInt32(19)
       self.property_[i].OutputPartial(out)
       out.putVarInt32(20)
@@ -3101,7 +3099,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3121,7 +3119,7 @@ class Index(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kentity_type = 1
   kancestor = 5
@@ -3375,7 +3373,7 @@ class CompositeIndex(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3393,7 +3391,7 @@ class CompositeIndex(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kapp_id = 1
   kid = 2
@@ -3530,7 +3528,7 @@ class IndexPostfix_IndexValue(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3545,7 +3543,7 @@ class IndexPostfix_IndexValue(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kproperty_name = 1
   kvalue = 2
@@ -3628,7 +3626,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
 
   def MergeFrom(self, x):
     assert x is not self
-    for i in xrange(x.index_value_size()): self.add_index_value().CopyFrom(x.index_value(i))
+    for i in range(x.index_value_size()): self.add_index_value().CopyFrom(x.index_value(i))
     if (x.has_key()): self.mutable_key().MergeFrom(x.key())
     if (x.has_before()): self.set_before(x.before())
 
@@ -3653,7 +3651,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
   def ByteSize(self):
     n = 0
     n += 1 * len(self.index_value_)
-    for i in xrange(len(self.index_value_)): n += self.lengthString(self.index_value_[i].ByteSize())
+    for i in range(len(self.index_value_)): n += self.lengthString(self.index_value_[i].ByteSize())
     if (self.has_key_): n += 1 + self.lengthString(self.key_.ByteSize())
     if (self.has_before_): n += 2
     return n
@@ -3661,7 +3659,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
   def ByteSizePartial(self):
     n = 0
     n += 1 * len(self.index_value_)
-    for i in xrange(len(self.index_value_)): n += self.lengthString(self.index_value_[i].ByteSizePartial())
+    for i in range(len(self.index_value_)): n += self.lengthString(self.index_value_[i].ByteSizePartial())
     if (self.has_key_): n += 1 + self.lengthString(self.key_.ByteSizePartial())
     if (self.has_before_): n += 2
     return n
@@ -3672,7 +3670,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
     self.clear_before()
 
   def OutputUnchecked(self, out):
-    for i in xrange(len(self.index_value_)):
+    for i in range(len(self.index_value_)):
       out.putVarInt32(10)
       out.putVarInt32(self.index_value_[i].ByteSize())
       self.index_value_[i].OutputUnchecked(out)
@@ -3685,7 +3683,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
       out.putBoolean(self.before_)
 
   def OutputPartial(self, out):
-    for i in xrange(len(self.index_value_)):
+    for i in range(len(self.index_value_)):
       out.putVarInt32(10)
       out.putVarInt32(self.index_value_[i].ByteSizePartial())
       self.index_value_[i].OutputPartial(out)
@@ -3717,7 +3715,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3740,7 +3738,7 @@ class IndexPostfix(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kindex_value = 1
   kkey = 2
@@ -3860,7 +3858,7 @@ class IndexPosition(ProtocolBuffer.ProtocolMessage):
         continue
 
 
-      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError()
       d.skipData(tt)
 
 
@@ -3872,7 +3870,7 @@ class IndexPosition(ProtocolBuffer.ProtocolMessage):
 
 
   def _BuildTagLookupTable(sparse, maxtag, default=None):
-    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+    return tuple([sparse.get(i, default) for i in range(0, 1+maxtag)])
 
   kkey = 1
   kbefore = 2

--- a/glibs/ndbkeyparser/ndb.py
+++ b/glibs/ndbkeyparser/ndb.py
@@ -51,12 +51,12 @@ class ConverterHelper(object):
         try:
             key = Key(urlsafe=value)
             if kind and key.kind() != kind:
-                raise ValueError
+                raise ValueError()
             return value
         except (ProtocolBuffer.ProtocolBufferDecodeError, TypeError):
             if kind:
                 return Key(kind, int(value), app=self._ndb_app).urlsafe()
-            raise ValueError
+            raise ValueError()
 
     def ensure_id(self, value):
         try:
@@ -66,7 +66,7 @@ class ConverterHelper(object):
             try:
                 return str(Key(urlsafe=value).id())
             except (ProtocolBuffer.ProtocolBufferDecodeError, TypeError):
-                raise ValueError
+                raise ValueError()
 
 
 # Everything from here on is ndb's code
@@ -107,9 +107,9 @@ def _DecodeUrlSafe(urlsafe):
 
     This returns the decoded string.
     """
-    if not isinstance(urlsafe, basestring):
+    if not isinstance(urlsafe, str):
         raise TypeError('urlsafe must be a string; received %r' % urlsafe)
-    if isinstance(urlsafe, unicode):
+    if isinstance(urlsafe, str):
         urlsafe = urlsafe.encode('utf8')
     mod = len(urlsafe) % 4
     if mod:
@@ -120,8 +120,8 @@ def _DecodeUrlSafe(urlsafe):
 
 def _ReferenceFromSerialized(serialized):
     """Construct a Reference from a serialized Reference."""
-    if not isinstance(serialized, basestring):
+    if not isinstance(serialized, str):
         raise TypeError('serialized must be a string; received %r' % serialized)
-    elif isinstance(serialized, unicode):
+    elif isinstance(serialized, str):
         serialized = serialized.encode('utf8')
     return entity_pb.Reference(serialized)


### PR DESCRIPTION
we're using ndb-key-parser in python3 environments such as geekie's airflow, requiring its code migration.

this PR is a result of running the tool `2to3`.

It's been validated in airflow's environment and it looks good.